### PR TITLE
Auto generate META.json using plugin [MetaJSON].

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/Author/ZOFFIX.pm
+++ b/lib/Dist/Zilla/PluginBundle/Author/ZOFFIX.pm
@@ -33,6 +33,7 @@ sub configure {
         PruneCruft
         ManifestSkip
         MetaYAML
+        MetaJSON
         License
         Readme
         ExecDir


### PR DESCRIPTION
Hi @zoffixznet 

Please review the PR.
I noticed the recently release distribution Kwalitee pointing missing META.json. 

https://cpants.cpanauthors.org/release/ZOFFIX/Mew-1.002002

I realised you are using Dist::Zilla::PluginBundle::Author::ZOFFIX in your configuration file. Therefore I decided, I better propose change to the source.

Many Thanks.
Best Regards,
Mohammad S Anwar